### PR TITLE
Fixing a typo in vocoder.py

### DIFF
--- a/models/tts/vocoder.py
+++ b/models/tts/vocoder.py
@@ -52,7 +52,7 @@ class Vocoder(object):
     
     def set_vocoder(self, model = None, model_class = None):
         if  model is None:
-            self.__vocoder = PTWaveGlow()
+            self.__vocoder = PtWaveGlow()
         elif isinstance(model, str):
             from models import get_pretrained
 


### PR DESCRIPTION
The class PtWaveGlow was called by a PTWaveGlow call, resulting an error